### PR TITLE
feat: add Location property to BaseMember

### DIFF
--- a/Src/Models/Field.cs
+++ b/Src/Models/Field.cs
@@ -17,6 +17,7 @@ public partial class Schema
 			m.Attributes = Attribute.From( member.CustomAttributes );
 			m.DocumentationId = builder.GetDocumentationId( member );
 			m.Documentation = builder.FindDocumentation( m.DocumentationId );
+			m.Location = Location.From( builder, member, t._projectPath );
 
 			return m;
 		}

--- a/Src/Models/Method.cs
+++ b/Src/Models/Method.cs
@@ -15,9 +15,6 @@ public partial class Schema
 		public bool IsSealed { get; set; }
 		public List<Parameter> Parameters { get; set; }
 
-		[JsonPropertyName( "l" )]
-		public Location Location { get; set; }
-
 		public class Parameter
 		{
 			public string Name { get; set; }

--- a/Src/Models/Property.cs
+++ b/Src/Models/Property.cs
@@ -11,9 +11,6 @@ public partial class Schema
 		public bool IsOverride { get; set; }
 		public bool IsSealed { get; set; }
 
-		[JsonPropertyName( "Loc" )]
-		public Location Location { get; set; }
-
 		internal static Property From( Builder builder, Type t, PropertyDefinition member )
 		{
 			var m = new Property();

--- a/Test/ProcessorTest.cs
+++ b/Test/ProcessorTest.cs
@@ -85,6 +85,12 @@ public class ProcessorTest
 		Assert.IsNotNull( maggie.Documentation );
 		Assert.IsNotNull( maggie.Documentation.Summary );
 
+		var population = sp.Fields.FirstOrDefault( x => x.Name == "Population" );
+		Assert.IsNotNull( population );
+		Assert.IsNotNull( population.Documentation );
+		Assert.IsNotNull( population.Documentation.Summary );
+		Assert.IsNotNull( population.Location );
+
 		var lisa = sp.Properties.FirstOrDefault( x => x.Name == "Lisa" );
 		Assert.IsNotNull( lisa );
 		Assert.IsNotNull( lisa.Documentation );

--- a/Test/Targets/Springfield.cs
+++ b/Test/Targets/Springfield.cs
@@ -12,6 +12,11 @@ public partial class Springfield : Town
 	public float Maggie;
 
 	/// <summary>
+	/// How many people live in Springfield
+	/// </summary>
+	public static int Population = 30000;
+
+	/// <summary>
 	/// An annoying know it all
 	/// </summary>
 	[Tag( "nerd" )]


### PR DESCRIPTION
This PR does a couple of things:
- Standardise the Location JSON property to "Loc", as it was "Loc" in Properties but "l" in Methods.
- Raise the Location property up to BaseMember
- Add Location property to fields. This will only work with fields that have an initialiser (and thus matching opcodes to find the source line). This is useful mainly for static fields on classes that have a set value.